### PR TITLE
Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     },
     "require": {
-        "php": "^7.2.5|^8.0|^8.1",
-        "illuminate/config": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
-        "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
+        "php": "^7.2.5|^8.0|^8.1|^8.2",
+        "illuminate/config": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/database": "^7.0|^8.0|^9.0|^10.0|^11.0",
         "paragonie/ciphersweet": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^9.0"
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^9.0|^10.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
         }
     },
     "require": {
-        "php": "^8.1",
-        "illuminate/config": "^10.0",
-        "illuminate/support": "^10.0",
-        "illuminate/database": "^10.0",
+        "php": "^7.2.5|^8.0|^8.1",
+        "illuminate/config": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0",
+        "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
         "paragonie/ciphersweet": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,20 @@
         }
     },
     "require": {
-        "php": "^7.2.5|^8.0",
-        "illuminate/config": "^7.0|^8.0|^9.0",
-        "illuminate/support": "^7.0|^8.0|^9.0",
-        "illuminate/database": "^7.0|^8.0|^9.0",
+        "php": "^8.1",
+        "illuminate/config": "^10.0",
+        "illuminate/support": "^10.0",
+        "illuminate/database": "^10.0",
         "paragonie/ciphersweet": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0|^7.0",
+        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
         "phpunit/phpunit": "^9.0"
     },
     "extra": {
         "laravel": {
             "providers": [
-              "BjornVoesten\\CipherSweet\\CipherSweetServiceProvider"
+                "BjornVoesten\\CipherSweet\\CipherSweetServiceProvider"
             ]
         }
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,13 +4,11 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
     use InteractsWithDatabase;
-    use RefreshDatabase;
     use DatabaseMigrations;
 
     /**


### PR DESCRIPTION
See https://github.com/bjornvoesten/ciphersweet-for-laravel/pull/13 by [@Lopoi](https://github.com/Lopoi):

> Just added support for Laravel 10.
> 
> This is just to keep support for old projects.

